### PR TITLE
Patch: Fix string values for max-width and max-height

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -46,7 +46,10 @@ def setBrowserResizeImage(web_content, context):
         for direction in ["width", "height"]:
             if getUserOption(f"apply {m}imum {direction}{suffix}", False):
                 limit = getUserOption(f"{m}-{direction}", default)
-                css.append(f"""img {{{m}-{direction}: {limit}px}}""")
+                if str(limit).isdigit():
+                    css.append(f"""img {{{m}-{direction}: {limit}px}}""")
+                else:
+                    css.append(f"""img {{{m}-{direction}: {limit}}}""")
                 js.append(f"""const {m}_{direction} = "{limit}";""")
             else:
                 js.append(f"""const {m}_{direction} = null;""")

--- a/config.schema.json
+++ b/config.schema.json
@@ -24,12 +24,12 @@
       "default": true
     },
     "max-height": {
-      "type": "integer",
+      "type": ["integer", "string"],
       "description": "The maximum height of image by default, if \"apply maximum height when not resizing\" is checked.",
       "default": 200
     },
     "max-width": {
-      "type": "integer",
+      "type": ["integer", "string"],
       "description": "The maximum width of image by default, if \"apply maximum width when not resizing\" is checked.",
       "default": 200
     },


### PR DESCRIPTION
Config states:

```
*max-height/max-width: which limit to apply to image (only if previous value is set to true). Either a number, in which case it represents pixels, or a string with any valid css value. px, %.. see https://www.w3schools.com/cssref/css_units.asp
```

Yet config schema was not allowing for strings and the max-height/width resizing was only applying integer px values, but not strings of value-unit pairs.

Fix will allow string value-unit pairs (eg `"50%"`) to be applied properly. In case an integer as a string (ie within quotes), it will be continue to be applied with px suffix as if it was an integer.